### PR TITLE
Try Redwood project CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-
-      - name: Install
-        run: yarn
-
-      - name: Lint
-        run: yarn rw lint
-
-      - name: Check
-        run: yarn rw check
-
-      - name: Test
-        run: yarn rw test --no-watch
-        env:
-          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
-          DOMAIN_URL: "http://localhost:8910/"
-
-      - name: Build
-        run: yarn rw build
-
+      - name: Redwood Project CI
+        uses: redwoodjs/project-ci-action@v0.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
     steps:
       - name: Redwood Project CI
         uses: redwoodjs/project-ci-action@v0.1.1
+        env:
+          DOMAIN_URL: "http://localhost:8910/"


### PR DESCRIPTION
Let's try the new Redwood project CI action: https://github.com/marketplace/actions/redwood-build-lint-diagnostics-and-tests. Critically this means we won't have to use railway for postgres anymore, which was questionable to being with but I didn't know any better at the time. Now PRs from forks can run tests!