### PR TITLE
Colocate context in checkout service

### DIFF
--- a/api/src/services/checkouts/checkouts.js
+++ b/api/src/services/checkouts/checkouts.js
@@ -1,13 +1,17 @@
-import { context } from '@redwoodjs/graphql-server'
-
 import { db } from 'src/lib/db'
 import { stripe } from 'src/lib/stripe'
 
 /**
- * @param {'payment' | 'subscription'} mode
- * @param {{ id: string, quantity: number }} cart
+ * @type {'payment' | 'subscription'} Mode
+ * @type {{ id: string, quantity: number }} Cart
+ *
+ * @param {{
+ *  mode: Mode
+ *  cart: Cart
+ *  customerId: string
+ * }}
  */
-export const checkout = async ({ mode, cart, customerId }) => {
+export const checkout = async ({ mode, cart, customerId }, { context }) => {
   // eslint-disable-next-line camelcase
   const line_items = cart.map((product) => ({
     price: product.id,

--- a/api/src/services/checkouts/checkouts.test.js
+++ b/api/src/services/checkouts/checkouts.test.js
@@ -2,16 +2,6 @@ import { stripe } from 'src/lib/stripe'
 
 import { checkout } from './checkouts'
 
-jest.mock('@redwoodjs/graphql-server', () => ({
-  context: {
-    event: {
-      headers: {
-        referer: 'http://localhost:8910/',
-      },
-    },
-  },
-}))
-
 describe('checkout', () => {
   it('Creates a checkout session given a cart', async () => {
     const cart = [
@@ -27,11 +17,22 @@ describe('checkout', () => {
 
     stripe.checkout.sessions.create = jest.fn(() => ({ id: 1 }))
 
-    const session = await checkout({
-      mode: 'payment',
-      cart,
-      customerId: 'cus0000001',
-    })
+    const session = await checkout(
+      {
+        mode: 'payment',
+        cart,
+        customerId: 'cus0000001',
+      },
+      {
+        context: {
+          event: {
+            headers: {
+              referer: 'http://localhost:8910/',
+            },
+          },
+        },
+      }
+    )
 
     expect(stripe.checkout.sessions.create).toMatchInlineSnapshot(`
       [MockFunction] {


### PR DESCRIPTION
I forgot that context is available in the second arg to a service: https://redwoodjs.com/docs/graphql#redwoods-resolver-args. Easier to use it there than as a global (for testing purposes). But it may be even better still to have the frontend pass it through though. TBD.