### PR TITLE
Add VSCode launch.json for api side debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,26 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "configurations": [
     {
-      "command": "yarn redwood dev",
-      "name": "launch development",
+      "command": "yarn redwood dev --apiDebugPort 18911",
+      "name": "Run Dev Server",
       "request": "launch",
       "type": "node-terminal"
+    },
+    {
+      "name": "Attach API debugger",
+      "port": 18911, // you can change this port, see https://redwoodjs.com/docs/project-configuration-dev-test-build#debugger-configuration
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node",
+      "protocol": "inspector",
+      "stopOnEntry": false,
+      "localRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
+      "remoteRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
+      "sourceMaps": true,
+      "restart": true
     }
   ]
 }


### PR DESCRIPTION
Added in https://github.com/redwoodjs/redwood/pull/4904. Have to copy it over to our template here. See Danny's mini video tutorial here: https://www.youtube.com/watch?v=LBPCAFO2I1k.