### PR TITLE
README: New "Test mode" text

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,10 @@ If you don't already have one, you can make one here: https://dashboard.stripe.c
 
 Once you've made your account, if you weren't automatically redirected, navigate to your [test dashboard](https://dashboard.stripe.com/test/dashboard). You'll find your test keys on the right side of the page:
 
-![image](https://user-images.githubusercontent.com/32992335/143495019-3c6319d3-f793-48c9-86ca-72f4c12f0306.png)
+![image](https://user-images.githubusercontent.com/30793/180631063-97aa9cca-6343-4c8d-a0ae-28c1bb9e5e70.png)
 
-> **Make sure "Test mode" is on**
->
-> You can toggle "Test mode" on and off with the toggle in the upper right.
-> Make sure it's always on. You should always see the orange "Test Data" banner.
+> If you have activtaed your account you can toggle "Test mode" on and off with the toggle in the upper right.
+> Make sure it's always on.
 
 Now that you've got your test keys, your `.env` should look like:
 


### PR DESCRIPTION
It seems Stripe has made some changes to their dashboard. For this readme the main change is the removal of orange "Test mode" bar at the top. I've updated the text in the readme to not mention it anymore.

There's also minor copy and layout changes in the circled section with the keys.

Honestly, it's still super easy to follow the readme, so if you just want to close this PR that's fine 🙂  And also, of course, do verify that the dashboard has changed for you as well. Can also be something they're just testing for a small subset of users, who knows 🙂