### PR TITLE
Button: forward ref

### DIFF
--- a/web/src/components/Button/Button.js
+++ b/web/src/components/Button/Button.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { Link } from '@redwoodjs/router'
 
-const Button = ({ children, ...props }) => {
+const Button = React.forwardRef(({ children, ...props }, ref) => {
   const { to, variant, ...rest } = props
 
   let Component
@@ -23,14 +23,18 @@ const Button = ({ children, ...props }) => {
 
   if (to) {
     return (
-      <Component as={StyledLink} to={to} {...rest}>
+      <Component as={StyledLink} to={to} {...rest} ref={ref}>
         {children}
       </Component>
     )
   }
 
-  return <Component {...rest}>{children}</Component>
-}
+  return (
+    <Component {...rest} ref={ref}>
+      {children}
+    </Component>
+  )
+})
 
 export default Button
 


### PR DESCRIPTION
I got this error when just visiting the home page (`localhost:8910/`)

![image](https://user-images.githubusercontent.com/30793/180638989-bf909538-05e5-4aa7-8d95-3530b1c47846.png)

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `Styled(Button)`.
    at Button (http://localhost:8910/static/js/app.bundle.js:4262:23)
    at O (http://localhost:8910/static/js/app.bundle.js:66494:19801)
    at http://localhost:8910/static/js/app.bundle.js:1476:803
    at http://localhost:8910/static/js/app.bundle.js:1476:95
    at http://localhost:8910/static/js/app.bundle.js:1454:200
    at http://localhost:8910/static/js/app.bundle.js:1297:1048
    at s (http://localhost:8910/static/js/app.bundle.js:1247:946)
    at Dialog (http://localhost:8910/static/js/app.bundle.js:1297:158)
    at Cart (http://localhost:8910/static/js/app.bundle.js:4406:82)
    at header
    at O (http://localhost:8910/static/js/app.bundle.js:66494:19801)
    at div
    at O (http://localhost:8910/static/js/app.bundle.js:66494:19801)
    at MainLayout (http://localhost:8910/static/js/app.bundle.js:5229:23)
    at CartProvider (http://localhost:8910/static/js/app.bundle.js:4779:23)
```

As you can see from the stack trace it comes from the `<Cart>` component, and it involves some `<Dialog>` component plus `<Button>`. Looking at the source for Cart we see this:

```
<Dialog.Trigger asChild>
  <ShoppingCartButton
    aria-label="Open cart"
    variant="icon"
    data-quantity={quantity}
    {...props}
  >
    <ShoppingCart style={{ transform: 'translateX(-2px)' }} />
  </ShoppingCartButton>
</Dialog.Trigger>
```

The key thing to notice here is `asChild` on `<Dialog.Trigger>`. For that to work the child needs to forward the ref that's passed to it. This PR adds that to our custom `<Button>`